### PR TITLE
return container in provideCommunicationLayerDependencies

### DIFF
--- a/src/Spryker/Zed/CmsContentWidget/CmsContentWidgetDependencyProvider.php
+++ b/src/Spryker/Zed/CmsContentWidget/CmsContentWidgetDependencyProvider.php
@@ -49,6 +49,8 @@ class CmsContentWidgetDependencyProvider extends AbstractBundleDependencyProvide
         $container[static::SERVICE_UTIL_ENCODING] = function (Container $container) {
             return new CmsContentWidgetToUtilEncodingBridge($container->getLocator()->utilEncoding()->service());
         };
+
+        return $container;
     }
 
     /**


### PR DESCRIPTION
Added a return statement to return $container. Currently cannot use this provider in communication layer because of that problem. Only way is to completely overwrite provideCommunicationLayerDependencies function